### PR TITLE
Post-boot checks

### DIFF
--- a/app/plugins/built-ins/PostBootChecks/PostBootChecks.tsx
+++ b/app/plugins/built-ins/PostBootChecks/PostBootChecks.tsx
@@ -20,6 +20,39 @@ class PostBootChecks {
   private _pluginCache = new PluginCacheTracker<Dependencies>(pluginList).pluginCache;
 
   constructor() {
+    this.ensureProdAssetsExist();
+  }
+
+  ensureProdAssetsExist() {
+    fs.stat('./prodHqAssets', (error) => {
+      if (error) {
+        window.$modal.alert({
+          header: 'Assets Incomplete',
+          body: (
+            <div>
+              The high-quality assets pack is missing; you'll only see
+              basic assets, and no stars will be visible.
+              <br/><br/>
+              Please download the "Stand-Alone Production Assets" pack from
+              the Cosmosis page, which contains all HQ assets:
+              <ul>
+                <li>
+                  <a
+                    href="#"
+                    onClick={() => {
+                      // @ts-ignore - nw is valid.
+                      nw.Shell.openExternal('https://github.com/frostoven/Cosmosis/releases');
+                    }}
+                  >
+                    github.com/frostoven/Cosmosis/releases
+                  </a>
+                </li>
+              </ul>
+            </div>
+          ),
+        });
+      }
+    });
   }
 }
 

--- a/app/plugins/built-ins/PostBootChecks/PostBootChecks.tsx
+++ b/app/plugins/built-ins/PostBootChecks/PostBootChecks.tsx
@@ -1,0 +1,33 @@
+import fs from 'fs';
+import React from 'react';
+import CosmosisPlugin from '../../types/CosmosisPlugin';
+import Core from '../Core';
+import Player from '../Player';
+import PluginCacheTracker from '../../../emitters/PluginCacheTracker';
+
+// -- ✀ Plugin boilerplate ----------------------------------------------------
+
+const pluginDependencies = {
+  core: Core,
+  player: Player,
+};
+const pluginList = Object.keys(pluginDependencies);
+type Dependencies = typeof pluginDependencies;
+
+// -- ✀ -----------------------------------------------------------------------
+
+class PostBootChecks {
+  private _pluginCache = new PluginCacheTracker<Dependencies>(pluginList).pluginCache;
+
+  constructor() {
+  }
+}
+
+const postBootChecksPlugin = new CosmosisPlugin(
+  'postBootChecks', PostBootChecks, pluginDependencies,
+);
+
+export {
+  PostBootChecks,
+  postBootChecksPlugin,
+};

--- a/app/plugins/pluginsEnabled.ts
+++ b/app/plugins/pluginsEnabled.ts
@@ -32,6 +32,7 @@ import { devGimbalPlugin } from './built-ins/DevGimbal';
 import { reactBasePlugin } from './built-ins/ReactBase';
 import { buckledPassengerPlugin } from './built-ins/modes/playerControllers/BuckledPassenger';
 import { localSpacePlugin } from './built-ins/LocalSpace';
+import { postBootChecksPlugin } from './built-ins/PostBootChecks/PostBootChecks';
 
 const builtInPluginsEnabled: PluginEntry[] = [
   // General
@@ -90,7 +91,8 @@ const builtInPluginsEnabled: PluginEntry[] = [
   // ------------------------------------------------------------ //
 
   // // Dev plugins
-  { name: 'devGimbalPlugin', pluginInstance: devGimbalPlugin, dependencies: [ 'core', 'player' ] },
+  { name: 'devGimbal', pluginInstance: devGimbalPlugin, dependencies: [ 'core', 'player' ] },
+  { name: 'postBootChecks', pluginInstance: postBootChecksPlugin, dependencies: [ '*' ] },
 ];
 
 generatePluginCompletion(builtInPluginsEnabled, 'PluginNames');

--- a/app/plugins/types/PluginNames.ts
+++ b/app/plugins/types/PluginNames.ts
@@ -32,7 +32,8 @@ type PluginNames =
   'externalLightsModule' | 
   'multimeterModule' | 
   'shipModuleHub' | 
-  'devGimbalPlugin';
+  'devGimbal' | 
+  'postBootChecks';
 
 export {
   PluginNames,

--- a/css/app.css
+++ b/css/app.css
@@ -20,6 +20,16 @@ html, body {
     cursor: url(/potatoLqAssets/icons/cursor1_sharp_32.png) 3 3, auto;
 }
 
+a {
+    color: #ffd07f;
+    font-weight: bold;
+}
+
+a:hover {
+    color: #d4ffa0;
+    font-weight: bold;
+}
+
 #galaxy-canvas, #far-object-canvas, #near-object-canvas {
     position: fixed;
     top: 0;


### PR DESCRIPTION
This PR adds a plugin meant for post-boot checks.

The first check added here ensures that the production assets directory is present. Since it's not part of the git repository, anyone cloning the repo (as opposed to just downloading the pre-built version) needs to be informed that they are missing assets. A message will now be displayed, forcing the user to acknowledge that the HQ asset directory is missing.
