### PR TITLE
Improved menu key cascade support

### DIFF
--- a/app/plugins/built-ins/Core/index.ts
+++ b/app/plugins/built-ins/Core/index.ts
@@ -26,10 +26,6 @@ const animationData = {
   // We multiply by 5 a lot in this game, so we have a premultiplied
   // convenience var for it here.
   bigDelta: 0,
-  // For situations where we want numbers to remain intuitive instead of
-  // varying wildly (i.e. close to non-delta'd) if we forgot to apply delta
-  // during initial design. Value is 1 at 120Hz, 2 at 60Hz, and 4 at 30Hz.
-  normalizedDelta: 0,
   // Interpolates between the previous and next frame. Can ease jitter in
   // visually-critical sections, but hurts accuracy during sudden frame drops.
   smoothDelta: 1,
@@ -113,7 +109,7 @@ export default class Core {
 
   static animationData: {
     delta: number; bigDelta: number, smoothDelta: number,
-    normalizedDelta: number, gpuDelta: number, j2000Time: number,
+    gpuDelta: number, j2000Time: number,
   } = animationData;
 
   // Do not place game logic in pre-animate. It's meant for setup used by
@@ -143,7 +139,6 @@ export default class Core {
   _updateCpuDeltas(delta: number) {
     animationData.delta = delta;
     animationData.bigDelta = delta * 5;
-    animationData.normalizedDelta = delta * 120;
     animationData.smoothDelta = lerp(animationData.smoothDelta, delta, 0.5);
     animationData.j2000Time = Date.now() * 0.001 - epoch;
   }

--- a/app/plugins/built-ins/InputManager/types/ModeId.ts
+++ b/app/plugins/built-ins/InputManager/types/ModeId.ts
@@ -10,7 +10,7 @@ enum ModeId {
   // don't work with game logic.
   appControl = 1,
   // The in-game menu that is launched when Escape is pressed.
-  menuControl = 2,
+  primaryGameMenu = 2,
   // Used for restricted movement such as looking around while in the pilot
   // seat.
   buckledPassenger = 3,

--- a/app/plugins/built-ins/PostBootChecks/PostBootChecks.tsx
+++ b/app/plugins/built-ins/PostBootChecks/PostBootChecks.tsx
@@ -1,24 +1,8 @@
 import fs from 'fs';
 import React from 'react';
 import CosmosisPlugin from '../../types/CosmosisPlugin';
-import Core from '../Core';
-import Player from '../Player';
-import PluginCacheTracker from '../../../emitters/PluginCacheTracker';
-
-// -- ✀ Plugin boilerplate ----------------------------------------------------
-
-const pluginDependencies = {
-  core: Core,
-  player: Player,
-};
-const pluginList = Object.keys(pluginDependencies);
-type Dependencies = typeof pluginDependencies;
-
-// -- ✀ -----------------------------------------------------------------------
 
 class PostBootChecks {
-  private _pluginCache = new PluginCacheTracker<Dependencies>(pluginList).pluginCache;
-
   constructor() {
     this.ensureProdAssetsExist();
   }
@@ -57,7 +41,7 @@ class PostBootChecks {
 }
 
 const postBootChecksPlugin = new CosmosisPlugin(
-  'postBootChecks', PostBootChecks, pluginDependencies,
+  'postBootChecks', PostBootChecks,
 );
 
 export {

--- a/app/plugins/built-ins/ReactBase/RootNode.tsx
+++ b/app/plugins/built-ins/ReactBase/RootNode.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { FadeInDown } from '../../../../reactExtra/animations/FadeInDown';
-import { InputManager } from '../../InputManager';
-import PluginCacheTracker from '../../../../emitters/PluginCacheTracker';
+import { FadeInDown } from '../../../reactExtra/animations/FadeInDown';
+import { InputManager } from '../InputManager';
+import PluginCacheTracker from '../../../emitters/PluginCacheTracker';
 import {
   RegisterMenuSignature,
   RegisteredMenu,
-} from '../types/compositionSignatures';
+} from './types/compositionSignatures';
 // import MenuHorizontal from '../menuTypes/MenuHorizontal';
 // import MenuVertical from '../menuTypes/MenuVertical';
 // import MenuGrid from '../menuTypes/MenuGrid';

--- a/app/plugins/built-ins/ReactBase/index.tsx
+++ b/app/plugins/built-ins/ReactBase/index.tsx
@@ -5,29 +5,49 @@ import {
   logBootTitleAndInfo,
   onDocumentReady,
 } from '../../../local/windowLoadListener';
-import ChangeTracker from 'change-tracker/src';
 import RootNode from './types/RootNode';
-import InputBridge from './types/InputBridge';
 import PluginLoader from '../../types/PluginLoader';
+import { RegisterMenuSignature } from './types/compositionSignatures';
 
 class ReactBase {
-  private _input = new InputBridge();
-  public onUiLoaded = new ChangeTracker();
-
-  private _rootNode = null;
+  private _rootNode: RootNode | null = null;
 
   constructor() {
     logBootTitleAndInfo('Driver', 'Human Interface Generics', PluginLoader.bootLogIndex);
     onDocumentReady(this.setupReact.bind(this));
   }
 
-  getInputBridge() {
-    return this._input;
-  }
+  registerMenu = (options: RegisterMenuSignature) => {
+    if (!this._rootNode) {
+      console.warn('Cannot open menu [name] - ReactBase still loading.');
+      return;
+    }
+
+    this._rootNode.registerMenu(options);
+  };
+
+  // noinspection JSUnusedGlobalSymbols - API function.
+  openMenu = (name: string) => {
+    this._rootNode?.openMenu(name);
+  };
+
+  // noinspection JSUnusedGlobalSymbols - API function.
+  closeMenu = (name: string) => {
+    this._rootNode?.closeMenu(name);
+  };
+
+  toggleMenu = (name: string) => {
+    this._rootNode?.toggleMenu(name);
+  };
+
+  // noinspection JSUnusedGlobalSymbols - API function.
+  getRegisteredMenuNames = () => {
+    return this._rootNode?.getRegisteredMenuNames();
+  };
 
   setupReact() {
     this._rootNode = ReactDOM.render(
-      <RootNode inputBridge={this._input}/>,
+      <RootNode/>,
       document.getElementById('reactRoot'),
     );
   }
@@ -38,4 +58,4 @@ const reactBasePlugin = new CosmosisPlugin('reactBase', ReactBase);
 export {
   ReactBase,
   reactBasePlugin,
-}
+};

--- a/app/plugins/built-ins/ReactBase/index.tsx
+++ b/app/plugins/built-ins/ReactBase/index.tsx
@@ -5,7 +5,7 @@ import {
   logBootTitleAndInfo,
   onDocumentReady,
 } from '../../../local/windowLoadListener';
-import RootNode from './types/RootNode';
+import RootNode from './RootNode';
 import PluginLoader from '../../types/PluginLoader';
 import { RegisterMenuSignature } from './types/compositionSignatures';
 

--- a/app/plugins/built-ins/ReactBase/menuTypes/MenuBasic.tsx
+++ b/app/plugins/built-ins/ReactBase/menuTypes/MenuBasic.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import InputBridge from '../types/InputBridge';
 import KosmButton from '../../../../reactExtra/components/KosmButton';
+import { RegisteredMenu } from '../types/compositionSignatures';
 
 const menuEntriesStyle: React.CSSProperties = {
   float: 'left',
@@ -41,6 +42,8 @@ type Entry = {
 };
 
 interface MenuBasicProps {
+  // Options used to make the plugin a menu-based mode controller.
+  pluginOptions: RegisteredMenu,
   // Settings used to build the menu.
   options: {
     // Menu entry index that is active when the menu opens. Defaults to 0.
@@ -62,7 +65,6 @@ interface MenuBasicProps {
 }
 
 export default class MenuBasic extends React.Component<MenuBasicProps> {
-  private _input = new InputBridge();
   public static defaultProps = {
     style: {},
     actionsNext: [ 'down' ],
@@ -75,7 +77,8 @@ export default class MenuBasic extends React.Component<MenuBasicProps> {
   };
 
   componentDidMount() {
-    this._input.onAction.getEveryChange(this.handleAction);
+    const input = this.props.pluginOptions.getInputBridge();
+    input.onAction.getEveryChange(this.handleAction);
     const defaultIndex = this.props.options.defaultIndex;
     if (this.state.selected === null && typeof defaultIndex === 'number') {
       this.setState({ selected: defaultIndex });
@@ -83,7 +86,8 @@ export default class MenuBasic extends React.Component<MenuBasicProps> {
   }
 
   componentWillUnmount() {
-    this._input.onAction.removeGetEveryChangeListener(this.handleAction);
+    const input = this.props.pluginOptions.getInputBridge();
+    input.onAction.removeGetEveryChangeListener(this.handleAction);
   }
 
   handleAction = (action: string) => {

--- a/app/plugins/built-ins/ReactBase/menuTypes/MenuGrid.tsx
+++ b/app/plugins/built-ins/ReactBase/menuTypes/MenuGrid.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import InputBridge from '../types/InputBridge';
 import KosmButton from '../../../../reactExtra/components/KosmButton';
+import { RegisteredMenu } from '../types/compositionSignatures';
 
 const menuEntriesStyle: React.CSSProperties = {
   float: 'left',
@@ -18,6 +18,8 @@ const centerBothStyle: React.CSSProperties = {
 type Entry = string[];
 
 interface MenuGridProps {
+  // Options used to make the plugin a menu-based mode controller.
+  pluginOptions: RegisteredMenu,
   // Settings used to build the menu.
   options: {
     // Menu entry index that is active when the menu opens. Defaults to [0, 0].
@@ -34,7 +36,6 @@ interface State {
 }
 
 export default class MenuGrid extends React.Component<MenuGridProps, State> {
-  private _input = new InputBridge();
   public static defaultProps = {
     style: {},
   };
@@ -44,16 +45,17 @@ export default class MenuGrid extends React.Component<MenuGridProps, State> {
   };
 
   componentDidMount() {
-    this._input.onAction.getEveryChange(this.handleAction);
+    const input = this.props.pluginOptions.getInputBridge();
+    input.onAction.getEveryChange(this.handleAction);
     const defaultIndex = this.props.options.defaultIndex;
-    console.log('--->', this.props.options);
     if (defaultIndex) {
       this.setState({ selected: defaultIndex });
     }
   }
 
   componentWillUnmount() {
-    this._input.onAction.removeGetEveryChangeListener(this.handleAction);
+    const input = this.props.pluginOptions.getInputBridge();
+    input.onAction.removeGetEveryChangeListener(this.handleAction);
   }
 
   handleAction = (action: string) => {
@@ -263,7 +265,6 @@ export default class MenuGrid extends React.Component<MenuGridProps, State> {
     }
 
     const name = entries[row][column];
-    console.log('selected', name);
   };
 
   render() {

--- a/app/plugins/built-ins/ReactBase/types/compositionSignatures.ts
+++ b/app/plugins/built-ins/ReactBase/types/compositionSignatures.ts
@@ -1,0 +1,21 @@
+import React from 'react';
+import InputBridge from './InputBridge';
+
+interface RegisterMenuSignature {
+  getInputBridge: () => InputBridge,
+  getComponent: () => typeof React.Component,
+  // If true, your menu will be closed if its mode control is deactivated.
+  // Default is true.
+  autoClose?: Boolean,
+  onActivate?: Function,
+}
+
+
+interface RegisteredMenu extends RegisterMenuSignature {
+  isVisible: boolean,
+}
+
+export {
+  RegisterMenuSignature,
+  RegisteredMenu,
+};

--- a/app/plugins/built-ins/SpacetimeControl/index.ts
+++ b/app/plugins/built-ins/SpacetimeControl/index.ts
@@ -59,7 +59,6 @@ class SpacetimeControl {
         }
       }
     });
-    console.log('--> _movementFunctions:', this._movementFunctions);
   }
 
   getLocalPosition() {

--- a/app/plugins/built-ins/modes/appControllers/GeneralControl/controls.ts
+++ b/app/plugins/built-ins/modes/appControllers/GeneralControl/controls.ts
@@ -6,12 +6,12 @@ import { ControlSchema } from '../../../InputManager/interfaces/ControlSchema';
 import { InputType } from '../../../../../configs/types/InputTypes';
 import { genAutoFriendlyNames } from '../../../InputManager/utils';
 
-const { pulse, continuous } = ActionType;
+const { pulse } = ActionType;
 const { keyboardButton } = InputType;
 
 const generalControls: ControlSchema = {
   openShipConsole:    { actionType: pulse, current: null, default: { Backquote: keyboardButton } },
-  activateGameMenu:   { actionType: pulse, current: null, default: { Backspace: keyboardButton } },
+  openOrCloseGameMenu:{ actionType: pulse, current: null, default: { Backspace: keyboardButton } },
   toggleMousePointer: { actionType: pulse, current: null, default: { ControlLeft: keyboardButton } },
   toggleFullScreen:   { actionType: pulse, current: null, default: { F11: keyboardButton } },
   showDevConsole:     { actionType: pulse, current: null, default: { F12: keyboardButton } },

--- a/app/plugins/built-ins/modes/appControllers/GeneralControl/index.ts
+++ b/app/plugins/built-ins/modes/appControllers/GeneralControl/index.ts
@@ -8,17 +8,25 @@ import { ReactBase } from '../../../ReactBase';
 import {
   toggleBootWindow,
 } from '../../../../../local/windowLoadListener';
+import PluginCacheTracker from '../../../../../emitters/PluginCacheTracker';
+
+// -- ✀ Plugin boilerplate ----------------------------------------------------
+
+const pluginDependencies = {
+  mouseDriver: MouseDriver,
+  reactBase: ReactBase,
+};
+const pluginList = Object.keys(pluginDependencies);
+type Dependencies = typeof pluginDependencies;
+
+// -- ✀ -----------------------------------------------------------------------
 
 class GeneralControl extends ModeController {
-  private _mouseDriver: MouseDriver;
-  private _reactBase: ReactBase;
+  private _pluginCache = new PluginCacheTracker<Dependencies>(pluginList).pluginCache;
 
   constructor() {
     const uiInfo = { friendly: 'General Controls', priority: 5 };
     super('general', ModeId.appControl, generalControls, uiInfo);
-
-    this._mouseDriver = gameRuntime.tracked.mouseDriver.cachedValue;
-    this._reactBase = gameRuntime.tracked.reactBase.cachedValue;
 
     this.pulse.openShipConsole.getEveryChange(() => {
       toggleBootWindow(true);
@@ -30,7 +38,7 @@ class GeneralControl extends ModeController {
 
     this.pulse.toggleMousePointer.getEveryChange(() => {
       // @ts-ignore - This is inherited from PointerLockControls.
-      this._mouseDriver.toggle();
+      this._pluginCache.mouseDriver.toggle();
     });
 
     this.pulse._devReloadGame.getEveryChange(() => {
@@ -51,12 +59,6 @@ class GeneralControl extends ModeController {
     // This controller activates itself by default:
     gameRuntime.tracked.inputManager.cachedValue.activateController(ModeId.appControl, this.name);
   }
-
-  _setupWatchers() {
-    gameRuntime.tracked.mouseDriver.getEveryChange((mouseDriver) => {
-      this._mouseDriver = mouseDriver;
-    });
-  }
 }
 
 const generalControlPlugin = new CosmosisPlugin('generalControl', GeneralControl);
@@ -64,4 +66,4 @@ const generalControlPlugin = new CosmosisPlugin('generalControl', GeneralControl
 export {
   GeneralControl,
   generalControlPlugin,
-}
+};

--- a/app/plugins/built-ins/modes/appControllers/GeneralControl/index.ts
+++ b/app/plugins/built-ins/modes/appControllers/GeneralControl/index.ts
@@ -32,8 +32,8 @@ class GeneralControl extends ModeController {
       toggleBootWindow(true);
     });
 
-    this.pulse.activateGameMenu.getEveryChange(() => {
-      this._reactBase.getInputBridge().activateAndOpenMenu();
+    this.pulse.openOrCloseGameMenu.getEveryChange(() => {
+      this._pluginCache.reactBase.toggleMenu('controlsMenu');
     });
 
     this.pulse.toggleMousePointer.getEveryChange(() => {

--- a/app/plugins/built-ins/modes/menuControllers/GameMenu/controls.ts
+++ b/app/plugins/built-ins/modes/menuControllers/GameMenu/controls.ts
@@ -1,15 +1,15 @@
 // @formatter:off
 // ^ Control-binding files become unreadable when formatted.
 
-import { ActionType } from '../../InputManager/types/ActionType';
-import { ControlSchema } from '../../InputManager/interfaces/ControlSchema';
-import { InputType } from '../../../../configs/types/InputTypes';
-import { genAutoFriendlyNames } from '../../InputManager/utils';
+import { ActionType } from '../../../InputManager/types/ActionType';
+import { ControlSchema } from '../../../InputManager/interfaces/ControlSchema';
+import { InputType } from '../../../../../configs/types/InputTypes';
+import { genAutoFriendlyNames } from '../../../InputManager/utils';
 
 const { pulse, continuous } = ActionType;
-const { keyboardButton, gamepadButton, mouseButton } = InputType;
+const { keyboardButton } = InputType;
 
-const reactMenuControls: ControlSchema = {
+const gameMenuControls: ControlSchema = {
   // Keys that may be held
   up:           { actionType: continuous, current: null, default: { ArrowUp: keyboardButton } },
   down:         { actionType: continuous, current: null, default: { ArrowDown: keyboardButton } },
@@ -25,13 +25,10 @@ const reactMenuControls: ControlSchema = {
   advanced:     { actionType: pulse, current: null, default: { F6: keyboardButton } },
   manageMacros: { actionType: pulse, current: null, default: { F4: keyboardButton } },
   emergencyMenuClose: { actionType: pulse, current: null, default: { KeyQ: keyboardButton } },
-  // Special entries
-  _openMenu:    { actionType: pulse, current: null, default: { /* handled by InputBridge directly */ } },
-  _closeMenu:   { actionType: pulse, current: null, default: { /* handled by InputBridge directly */ } },
 };
 
-genAutoFriendlyNames(reactMenuControls);
+genAutoFriendlyNames(gameMenuControls);
 
 export {
-  reactMenuControls,
+  gameMenuControls,
 };

--- a/app/plugins/built-ins/modes/menuControllers/GameMenu/index.ts
+++ b/app/plugins/built-ins/modes/menuControllers/GameMenu/index.ts
@@ -1,0 +1,47 @@
+import CosmosisPlugin from '../../../../types/CosmosisPlugin';
+import PluginCacheTracker from '../../../../../emitters/PluginCacheTracker';
+import { ReactBase } from '../../../ReactBase';
+import InputBridge from '../../../ReactBase/types/InputBridge';
+import { ModeId } from '../../../InputManager/types/ModeId';
+import MenuControlSetup from './MenuComponents/MenuControlSetup';
+import { gameMenuControls } from './controls';
+
+const MENU_NAME = 'controlsMenu';
+
+// -- ✀ Plugin boilerplate ----------------------------------------------------
+
+const pluginDependencies = {
+  reactBase: ReactBase,
+};
+type Dependencies = typeof pluginDependencies;
+const pluginList = Object.keys(pluginDependencies);
+
+// -- ✀ -----------------------------------------------------------------------+
+
+class GameMenu {
+  private _pluginCache = new PluginCacheTracker<Dependencies>(pluginList).pluginCache;
+  private _inputBridge = new InputBridge(
+    MENU_NAME, ModeId.primaryGameMenu, gameMenuControls, true,
+  );
+
+  constructor() {
+    this._inputBridge.autoConfigurePulseKeys([
+      'back', 'select', 'saveChanges', 'delete', 'resetBinding', 'search',
+      'advanced', 'manageMacros', 'emergencyMenuClose',
+    ]);
+
+    this._pluginCache.reactBase.registerMenu({
+      getInputBridge: () => this._inputBridge,
+      getComponent: () => MenuControlSetup,
+    });
+  }
+}
+
+const gameMenuPlugin = new CosmosisPlugin(
+  'gameMenu', GameMenu, pluginDependencies,
+);
+
+export {
+  GameMenu,
+  gameMenuPlugin,
+};

--- a/app/plugins/built-ins/modes/menuControllers/Navigation/NavigationConsole.tsx
+++ b/app/plugins/built-ins/modes/menuControllers/Navigation/NavigationConsole.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+class NavigationConsole extends React.Component {
+  render() {
+    return null;
+  }
+}
+
+export {
+  NavigationConsole,
+};

--- a/app/plugins/built-ins/modes/menuControllers/Navigation/controls.ts
+++ b/app/plugins/built-ins/modes/menuControllers/Navigation/controls.ts
@@ -1,0 +1,23 @@
+// @formatter:off
+// ^ Control-binding files become unreadable when formatted.
+
+import { ActionType } from '../../../InputManager/types/ActionType';
+import { ControlSchema } from '../../../InputManager/interfaces/ControlSchema';
+import { InputType } from '../../../../../configs/types/InputTypes';
+import { genAutoFriendlyNames } from '../../../InputManager/utils';
+
+const { continuous } = ActionType;
+const { keyboardButton } = InputType;
+
+const navMenuControls: ControlSchema = {
+  up:           { actionType: continuous, current: null, default: { ArrowUp: keyboardButton } },
+  down:         { actionType: continuous, current: null, default: { ArrowDown: keyboardButton } },
+  left:         { actionType: continuous, current: null, default: { ArrowLeft: keyboardButton } },
+  right:        { actionType: continuous, current: null, default: { ArrowRight: keyboardButton } },
+};
+
+genAutoFriendlyNames(navMenuControls);
+
+export {
+  navMenuControls,
+};

--- a/app/plugins/built-ins/modes/menuControllers/Navigation/index.ts
+++ b/app/plugins/built-ins/modes/menuControllers/Navigation/index.ts
@@ -1,0 +1,46 @@
+import CosmosisPlugin from '../../../../types/CosmosisPlugin';
+import PluginCacheTracker from '../../../../../emitters/PluginCacheTracker';
+import { ReactBase } from '../../../ReactBase';
+import InputBridge from '../../../ReactBase/types/InputBridge';
+import { ModeId } from '../../../InputManager/types/ModeId';
+import { NavigationConsole } from './NavigationConsole';
+import { navMenuControls } from './controls';
+
+const MENU_NAME = 'navMenu';
+
+// -- ✀ Plugin boilerplate ----------------------------------------------------
+
+const pluginDependencies = {
+  reactBase: ReactBase,
+};
+type Dependencies = typeof pluginDependencies;
+const pluginList = Object.keys(pluginDependencies);
+
+// -- ✀ -----------------------------------------------------------------------+
+
+class NavMenu {
+  private _pluginCache = new PluginCacheTracker<Dependencies>(pluginList).pluginCache;
+  private _inputBridge = new InputBridge(
+    MENU_NAME, ModeId.virtualMenuControl, navMenuControls, true,
+  );
+
+  constructor() {
+    // this._inputBridge.autoConfigurePulseKeys([
+    //   // TBA
+    // ]);
+
+    this._pluginCache.reactBase.registerMenu({
+      getInputBridge: () => this._inputBridge,
+      getComponent: () => NavigationConsole,
+    });
+  }
+}
+
+const navMenuPlugin = new CosmosisPlugin(
+  'navMenu', NavMenu, pluginDependencies,
+);
+
+export {
+  NavMenu,
+  navMenuPlugin,
+};

--- a/app/plugins/built-ins/ui/Hud3D/index.ts
+++ b/app/plugins/built-ins/ui/Hud3D/index.ts
@@ -24,7 +24,6 @@ class Hud3D {
   // player's visor, though it's only been tested with the player's visor. We
   // can probably implement some mesh codes that request things by page name.
   setScreenPage(page: HudPage, targetParent: THREE.Object3D) {
-    console.log('targetParent:', targetParent);
     gameRuntime.tracked.levelScene.getOnce(() => {
       const trackedParent = this._trackedParents[targetParent.uuid];
 

--- a/app/plugins/pluginsEnabled.ts
+++ b/app/plugins/pluginsEnabled.ts
@@ -33,6 +33,8 @@ import { reactBasePlugin } from './built-ins/ReactBase';
 import { buckledPassengerPlugin } from './built-ins/modes/playerControllers/BuckledPassenger';
 import { localSpacePlugin } from './built-ins/LocalSpace';
 import { postBootChecksPlugin } from './built-ins/PostBootChecks/PostBootChecks';
+import { gameMenuPlugin } from './built-ins/modes/menuControllers/GameMenu';
+import { navMenuPlugin } from './built-ins/modes/menuControllers/Navigation';
 
 const builtInPluginsEnabled: PluginEntry[] = [
   // General
@@ -59,6 +61,8 @@ const builtInPluginsEnabled: PluginEntry[] = [
 
   // React UI
   { name: 'reactBase', pluginInstance: reactBasePlugin, dependencies: [ 'core', 'inputManager' ] },
+  { name: 'gameMenu', pluginInstance: gameMenuPlugin, dependencies: [ 'reactBase' ] },
+  { name: 'navMenu', pluginInstance: navMenuPlugin, dependencies: [ 'reactBase' ] },
 
   // Modes
   { name: 'generalControl', pluginInstance: generalControlPlugin, dependencies: [ 'inputManager', 'reactBase' ] },

--- a/app/plugins/types/PluginNames.ts
+++ b/app/plugins/types/PluginNames.ts
@@ -19,6 +19,8 @@ type PluginNames =
   'inputManager' | 
   'gamepadConnector' | 
   'reactBase' | 
+  'gameMenu' | 
+  'navMenu' | 
   'generalControl' | 
   'freeCam' | 
   'buckledPassenger' | 

--- a/css/kosm.css
+++ b/css/kosm.css
@@ -102,7 +102,8 @@
 
 /* Modal background. */
 .ui.modal.transition.visible.active.kosm-modal {
-    background: #333333 !important;
+    background-color: rgb(25 28 27);
+    border-radius: 8px;
 }
 
 .kosm-half-wide {
@@ -183,6 +184,11 @@
 .kosm-modal {
     z-index: 9999;
     white-space: pre-line;
+}
+
+.kosm-modal .header {
+    background: url("/css/debuggerImages/background-2.png") -12px center !important;
+    border-radius: 8px 8px 0 0 !important;
 }
 
 .kosm-statusbar, .kosm-statusbar-sub {

--- a/css/react.css
+++ b/css/react.css
@@ -139,7 +139,7 @@ border: none !important;
 
 .ui.modal > .content {
     /* TODO: this background kinda kills the button gradients. Find a fix. */
-    background: #6c6c6cc9 !important;
+    background: rgba(33, 33, 37) !important;
 }
 
 .floating-footer {


### PR DESCRIPTION
It is now possible to write menus as complete mode controllers. That is, if a higher priority menu (or non-menu ship interface) has priority over a key binding, the game will correctly send the key action to the higher-priority interface.

Additional features:
* Modals are now a bit prettier.
